### PR TITLE
Remocao id token e refatoracao verify

### DIFF
--- a/src/Utils/BankingConnection.php
+++ b/src/Utils/BankingConnection.php
@@ -53,14 +53,9 @@ class BankingConnection extends Connection
                 $response = $this->auth($params);
 
                 if($response['code'] == 200){
-                    $token['id_token'] = $response['response']['id_token'];
-                    $token['token_type'] = $response['response']['token_type'];
-                    $token['access_token'] = $response['response']['access_token'];
-                    $token['expires_in'] = $response['response']['expires_in'];
-                    $token['refresh_token'] = $response['response']['refresh_token'];
-                    $token['refresh_expires_in'] = $response['response']['refresh_expires_in'];
-                    $token['scope'] = $response['response']['scope'];
+                    $token = $response['response'];
                     $token['created_at'] = now();
+
 
                     $_SESSION["sicrediToken"] = $token;
 
@@ -82,13 +77,7 @@ class BankingConnection extends Connection
         $response = $this->auth($params);
 
         if($response['code'] == 200){
-            $token['id_token'] = $response['response']['id_token'];
-            $token['token_type'] = $response['response']['token_type'];
-            $token['access_token'] = $response['response']['access_token'];
-            $token['expires_in'] = $response['response']['expires_in'];
-            $token['refresh_token'] = $response['response']['refresh_token'];
-            $token['refresh_expires_in'] = $response['response']['refresh_expires_in'];
-            $token['scope'] = $response['response']['scope'];
+            $token = $response['response'];
             $token['created_at'] = now();
 
             $_SESSION["sicrediToken"] = $token;

--- a/src/Utils/BankingConnection.php
+++ b/src/Utils/BankingConnection.php
@@ -15,11 +15,11 @@ class BankingConnection extends Connection
             session_start();
         }
 
-        $this->baseUrl  = config('sicredi.base_url');
-        $this->apiKey   = config('sicredi.x_api_key');
-        $this->username = config('sicredi.basic_user');
-        $this->password = config('sicredi.basic_password');
-        $this->path     = config('sicredi.certificate_path');
+        $this->baseUrl    = config('sicredi.base_url');
+        $this->apiKey     = config('sicredi.x_api_key');
+        $this->username   = config('sicredi.basic_user');
+        $this->password   = config('sicredi.basic_password');
+        $this->verify_ssl = config('sicredi.verify_ssl');
 
         $this->getAccessToken();
     }
@@ -46,7 +46,7 @@ class BankingConnection extends Connection
                     'apiKey'    => $this->apiKey,
                     'username'  => $this->username,
                     'password'  => $this->password,
-                    'path'      => $this->path,
+                    'verify_ssl'=> $this->verify_ssl,
                     'refresh'   => $token['refresh_token']
                 ];
 
@@ -71,7 +71,7 @@ class BankingConnection extends Connection
             'apiKey'    => $this->apiKey,
             'username'  => $this->username,
             'password'  => $this->password,
-            'path'      => $this->path,
+            'verify_ssl'=> $this->verify_ssl,
         ];
 
         $response = $this->auth($params);

--- a/src/config/sicredi.php
+++ b/src/config/sicredi.php
@@ -5,7 +5,7 @@ return [
     'basic_user'       => env('SICREDI_BASIC_USER', ''),
     'basic_password'   => env('SICREDI_BASIC_PASSWORD', ''),
     'x_api_key'        => env('SICREDI_API_KEY', ''),
-    'certificate_path' => env('SICREDI_CERTIFICATE', ''),
+    'verify_ssl'       => env('SICREDI_VERIFY_SSL', ''),
     'cooperativa'      => env('SICREDI_COOPERATIVA'), '',
     'posto'            => env('SICREDI_POSTO', ''),
 ];


### PR DESCRIPTION
Alteração de certificate_path para verify_ssl, trazendo a flexibilidade de verificar ou não o ssl e também verificar com todas as opções possíveis

```
// Use the system's CA bundle (this is the default setting)
$client->request('GET', '/', ['verify' => true]);

// Use a custom SSL certificate on disk.
$client->request('GET', '/', ['verify' => '/path/to/cert.pem']);

// Disable validation entirely (don't do this!).
$client->request('GET', '/', ['verify' => false]);
```


----

 Correção do erro id_token - Alteração do mapeamento 1 = 1 para receber o objeto, corrigindo o erro de 'id_token' indefinido